### PR TITLE
Replaced old docker/boot2docker

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -24,11 +24,8 @@ brew 'hub'
 
 brew 'golang'
 
-brew 'docker'
-
-brew 'boot2docker'
-
 cask 'atom'
+cask 'docker'
 cask 'docker-toolbox'
 cask 'flux'
 cask 'sublime-text'


### PR DESCRIPTION
- Replaced with newer Docker for mac
- After install, simply run "Docker" from spotlight or /Applications/Docker
- This will start the new dockerd and setup Docker for execution