### PR TITLE
update homebrew via homebrew

### DIFF
--- a/mac
+++ b/mac
@@ -176,7 +176,7 @@ if tap_is_installed 'caskroom/versions'; then
 fi
 
 fancy_echo "Updating Homebrew ..."
-cd "$(brew --repo)" && git fetch && git reset --hard origin/master && brew update
+brew update && brew upgrade
 
 fancy_echo "Verifying the Homebrew installation..."
 if brew doctor; then


### PR DESCRIPTION
When using the older style of updating brew, for some reason `brew bundle` would throw an error claiming that brew needed to be updated...

<img width="360" alt="screen_shot_2017-09-19_at_3 40 43_pm_720" src="https://user-images.githubusercontent.com/1824546/30890421-dbb388de-a2fa-11e7-8e10-a23059b5d575.png">
